### PR TITLE
Fix to use aws sdk v3

### DIFF
--- a/ebfly.gemspec
+++ b/ebfly.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  # http://ruby.awsblog.com/post/TxFKSK2QJE6RPZ/Upcoming-Stable-Release-of-AWS-SDK-for-Ruby-Version-2
-  spec.add_runtime_dependency "aws-sdk-v1"
+  spec.add_runtime_dependency "aws-sdk-s3"
+  spec.add_runtime_dependency "aws-sdk-elasticbeanstalk"
   spec.add_runtime_dependency "thor"
 
   spec.add_development_dependency "rake"

--- a/lib/ebfly/command/env.rb
+++ b/lib/ebfly/command/env.rb
@@ -151,9 +151,9 @@ module Ebfly
 
     def upload_archive(file_name)
       puts "Upload archive #{file_name} to s3://#{s3_bucket}"
-      bucket = s3.buckets[s3_bucket]
-      obj = bucket.objects[file_name]
-      obj.write(Pathname.new(file_name))
+      bucket = s3.bucket(s3_bucket)
+      obj = bucket.object(file_name)
+      obj.put(body: Pathname.new(file_name).to_s)
     end
 
     def create_application_version(app, version, ish, file_name)

--- a/lib/ebfly/ebfly.rb
+++ b/lib/ebfly/ebfly.rb
@@ -27,12 +27,11 @@ module Ebfly
     SUPPORTED_SOLUTION_STACKS = ['Docker', 'Go', 'Node.js', 'PHP', 'Python', 'Ruby']
 
     def eb
-      @eb ||= AWS::ElasticBeanstalk.new
-      @eb.client
+      @eb ||= Aws::ElasticBeanstalk::Client.new
     end
 
     def s3
-      @s3 ||= AWS::S3.new
+      @s3 ||= Aws::S3::Resource.new
     end
 
     def run(&block)
@@ -61,10 +60,10 @@ module Ebfly
     def exist_command?(cmd)
       exts = ENV['PATHEXT'] ? ENV['PATHEXT'].split(';') : ['']
       ENV['PATH'].split(File::PATH_SEPARATOR).each do |path|
-      exts.each { |ext|
-        exe = File.join(path, "#{cmd}#{ext}")
-        return exe if File.executable? exe
-      }
+        exts.each { |ext|
+          exe = File.join(path, "#{cmd}#{ext}")
+          return exe if File.executable? exe
+        }
       end
       return nil
     end


### PR DESCRIPTION
## Issue
https://github.com/quipper/aya-issues/issues/23368

## Overview
Qworker uses this gem and we have to delete aws-sdk-v1 dependency for depreciation

ref: https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/ElasticBeanstalk/Client.html