### PR TITLE
Fix upload_archive

### DIFF
--- a/lib/ebfly/command/env.rb
+++ b/lib/ebfly/command/env.rb
@@ -153,7 +153,7 @@ module Ebfly
       puts "Upload archive #{file_name} to s3://#{s3_bucket}"
       bucket = s3.bucket(s3_bucket)
       obj = bucket.object(file_name)
-      obj.put(body: Pathname.new(file_name).to_s)
+      obj.put(body: File.open(file_name, 'rb'))
     end
 
     def create_application_version(app, version, ish, file_name)


### PR DESCRIPTION
Currenly, `ebfly` fails to deploy because invalid object is uploaded to S3.

We upgraded aws-sdk at https://github.com/quipper/ebfly/pull/1 , but the interface was changed.

At v1, S3Object#write will write File object specified by a pathname.
https://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/S3Object.html

At v3, We need to pass a File itself to S3::Object#push.
https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Object.html

@midwhite @yoshimaru46 @rbmrclo Please review merge 🙏 